### PR TITLE
feat(send): error handling and send func response

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 You need to create an instance to use the library. The constructor has a settings argument:
 
-- `afterPhoneLoaded`: Callback function after the phone is fully loaded and the connexion between the phone and the CRM is established
-- `integrationToLoad`: You can specify a CRM from which specific settings can be retrieved. Only `zendesk` available for now.
+- `onLogin`: Callback function after the phone is fully loaded, logged in, and the connexion between the phone and the CRM is established. This callback will triggers everytime the user logs again. User details and integration settings if any are passed as parameters.
+- `onLogout`: Callback function after the user logs out of the phone. It will triggers everytime the user logs out.
+- `integrationToLoad`: You can specify a CRM from which specific settings can be retrieved. Only `zendesk` or `hubspot` available for now.
 - `domToLoadPhone`: You must specify in which element you want to load the phone. Query selector string.
 
 Example:
@@ -18,22 +19,42 @@ Example:
 import AircallPhone from 'aircall-everywhere';
 
 const aircallPhone = new AircallPhone({
-  afterPhoneLoaded: () => {
+  onLogin: settings => {
     console.log('phone loaded');
     doStuff();
   },
+  onLogout: () => {},
   domToLoadPhone: '#phone',
   integrationToLoad: 'zendesk'
 });
 ```
 
-## getSetting
-
-You can retrieve specific integration settings with `getSetting`.
-Example with `zendesk`:
+Settings passed in the `onLogin` callback contains info about the user and integration and looks like this:
 
 ```javascript
-const redirectToTicket = aircallPhone.getSetting('display_ticket');
+{
+  user: {
+    email: 'john@company.com',
+    first_name: 'John',
+    last_name: 'Smith',
+    company_name: 'Super Company Inc'
+  },
+  settings: {
+    <specific_integration_settings>
+  }
+}
+```
+
+## isLoggedIn method
+
+In addition to the `onLogin` and `onLogout` callbacks, a `isLoggedIn` method is provided that will directly asks the phone about its status.
+
+Example:
+
+```javascript
+aircallPhone.isLoggedIn(res => {
+  console.log('login status:', res);
+});
 ```
 
 ## on & send
@@ -44,7 +65,7 @@ You can send messages to the phone and listen messages coming from it.
 
 - `incoming_call`: the phone is ringing
 - `call_end_ringtone`: the ringtone has ended. It can mean the incoming call was taken or missed.
-- `redirect_event`: event coming from specific CRM settings if it has been enabled in the Aircall Dashboard. Only `zendesk` is supported for now. This event data has this schema:
+- `redirect_event`: event coming from specific CRM settings if it has been enabled in the Aircall Dashboard. Only `zendesk` and `hubspot` is supported for now. This event data has this schema:
   ```javascript
   {
     type: 'Zendesk::User' | 'Zendesk::Ticket'
@@ -54,33 +75,46 @@ You can send messages to the phone and listen messages coming from it.
 
 ### events the phone listens to:
 
-- `dial_number`: with `{phone_number: <number>}` argument, you can ask the phone to dial the number.
-- `exit_keyboard`: with no argument, you can ask the phone to exit the keyboard view if it is on.
-
-Full Example:
+Example:
 
 ```javascript
-import Aircall from 'aircall-everywhere';
-
-const aircallPhone = new AircallPhone({
-  afterPhoneLoaded: () => {
-    console.log('phone loaded');
-    doStuff();
-  },
-  domToLoadPhone: '#phone',
-  integrationToLoad: 'zendesk'
-});
-
-aircallPhone.on('incoming_call', () => {
-  putPhonePopupInFront();
-});
-
-myCRM.on('phone_button_clicked_event', number => {
-  aircallPhone.send('dial_number', { phone_number: number });
+aircallPhone.send('dial_number', { phone_number: number }, (success, data) => {
+  console.log('success of dial:', success);
 });
 ```
 
+The callback of the `send` method has two arguments:
+
+- success of the request
+- if the request is successful, data from the response sent by the phone
+- if the request is not successful, an error object with an error code and error message:
+
+All generic errors from `send`:
+
+- `no_event_name`: the event name sent is not valid
+- `not_ready`: Phone is not loaded or logged in yet
+- `no_answer`: Phone didn't answer, most likely not logged in
+- `does_not_exists`: The event sent does not exists
+- `invalid_response`: Phone sent an malformed answer, should not happen
+- `unknown_error`: Should not happen
+
+List of events:
+
+- `dial_number`: with `{phone_number: <number>}` argument, you can ask the phone to dial the number.
+  Specific errors for this event:
+
+  - `in_call`: Phone is on a call, retry after the call is ended
+
+- `exit_keyboard`: with no argument, you can ask the phone to exit the keyboard view if it is on.
+  Specific errors for this event:
+  - `in_call`: Phone is on a call, retry after the call is ended
+  - `not_in_keyboard`: Phone is not on keyboard screen, so it can't exit the keyboard :D
+
 more events to come...
+
+## removeListener method
+
+You can remove a listener added by `on` with this method.
 
 # Development
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -47,7 +47,7 @@ loadPhoneButton.addEventListener(
           if (success) {
             dialSuccessAlert.classList.remove('d-none');
           } else {
-            //dialErrorAlert.textContent = `Error : ${data.message}`;
+            dialErrorAlert.textContent = 'Error : ' + data.message;
             dialErrorAlert.classList.remove('d-none');
           }
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -9,14 +9,22 @@ loadPhoneButton.addEventListener(
   () => {
     let loadedPhoneAlert = document.querySelector('#phone-loaded');
     let notLoadePhoneAlert = document.querySelector('#phone-not-loaded');
+    let userInfoText = document.querySelector('#user-info');
     loadPhoneButton.disabled = true;
     const ap = new AircallPhone({
       domToLoadPhone: '#phone',
-      afterPhoneLoaded: () => {
+      onLogin: settings => {
+        userInfoText.textContent = JSON.stringify(settings, null, 4);
         loadedPhoneAlert.classList.remove('d-none');
         notLoadePhoneAlert.classList.add('d-none');
+      },
+      onLogout: () => {
+        loadedPhoneAlert.classList.add('d-none');
+        notLoadePhoneAlert.classList.remove('d-none');
+        userInfoText.textContent = ' ';
       }
     });
+
     let inCallAlert = document.querySelector('#in-call');
     let notInCallAlert = document.querySelector('#not-in-call');
     ap.on('incoming_call', () => {
@@ -25,16 +33,48 @@ loadPhoneButton.addEventListener(
     });
 
     ap.on('call_end_ringtone', () => {
-      console.log('end ringtone');
       inCallAlert.classList.add('d-none');
       notInCallAlert.classList.remove('d-none');
     });
 
     let dialButton = document.querySelector('#dial-button');
+    let dialSuccessAlert = document.querySelector('#dial-number-success');
+    let dialErrorAlert = document.querySelector('#dial-number-error');
     dialButton.addEventListener(
       'click',
       () => {
-        ap.send('dial_number', { phone_number: '+33123456789' });
+        ap.send('dial_number', { phone_number: '+33123456789' }, (success, data) => {
+          if (success) {
+            dialSuccessAlert.classList.remove('d-none');
+          } else {
+            //dialErrorAlert.textContent = `Error : ${data.message}`;
+            dialErrorAlert.classList.remove('d-none');
+          }
+
+          setTimeout(() => {
+            dialSuccessAlert.classList.add('d-none');
+            dialErrorAlert.classList.add('d-none');
+          }, 2000);
+        });
+      },
+      false
+    );
+
+    let isLoginButton = document.querySelector('#is-login-button');
+    let isLoggedInAlert = document.querySelector('#is-logged-in');
+    let isLoggedOutAlert = document.querySelector('#is-logged-out');
+    isLoginButton.addEventListener(
+      'click',
+      () => {
+        ap.isLoggedIn(res => {
+          res
+            ? isLoggedInAlert.classList.remove('d-none')
+            : isLoggedOutAlert.classList.remove('d-none');
+          setTimeout(() => {
+            isLoggedInAlert.classList.add('d-none');
+            isLoggedOutAlert.classList.add('d-none');
+          }, 2000);
+        });
       },
       false
     );

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -25,6 +25,7 @@ loadPhoneButton.addEventListener(
     });
 
     ap.on('call_end_ringtone', () => {
+      console.log('end ringtone');
       inCallAlert.classList.add('d-none');
       notInCallAlert.classList.remove('d-none');
     });

--- a/demo/index.html
+++ b/demo/index.html
@@ -155,7 +155,7 @@ ap.on('call_end_ringtone', () => {
       if (success) {
         dialSuccessAlert.classList.remove('d-none');
       } else {
-        dialErrorAlert.textContent = 'Error : ' + error.message;
+        dialErrorAlert.textContent = 'Error : ' + data.message;
         dialErrorAlert.classList.remove('d-none');
       }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -81,18 +81,27 @@
             <h4>Load Aircall phone in a div:</h4>
               <pre><code>const ap = new AircallPhone({
   domToLoadPhone: '#phone',
-  afterPhoneLoaded: () => {
+  onLogin: settings => {
+    userInfoText.textContent = JSON.stringify(settings, null, 4);
     loadedPhoneAlert.classList.remove('d-none');
-    notLoadedPhoneAlert.classList.add('d-none');
+    notLoadePhoneAlert.classList.add('d-none');
+  },
+  onLogout: () => {
+    loadedPhoneAlert.classList.remove('d-none');
+    notLoadePhoneAlert.classList.add('d-none');
   }
+});
 });</code></pre>
             <button type="button" class="btn btn-primary mb-2" id="load-phone-button">Load phone</button>
             <div class="alert alert-success d-none" role="alert" id="phone-loaded">
-              Phone is loaded and ready to interact
+              Phone is logged in and ready to interact
             </div>
             <div class="alert alert-danger" role="alert" id="phone-not-loaded">
-              Phone is not loaded
+              Phone is not loaded or logged in
             </div>
+
+            <p>Aircall user information</p>
+            <pre><code id="user-info"> </code></pre>
 
             <h4>Listening to phone events:</h4>
               <pre><code>ap.on('incoming_call', () => {
@@ -112,10 +121,59 @@ ap.on('call_end_ringtone', () => {
             </div>
 
             <h4>Sending events to phone:</h4>
-              <pre><code>dialButton.addEventListener('click', () => {
-  ap.send('dial_number', {phone_number: '+33123456789'});
-}, false);</code></pre>
+
+            <p>Special method for login status:</p>
+            <pre><code>isLoginButton.addEventListener(
+  'click',
+  () => {
+    ap.isLoggedIn(res => {
+      res
+        ? isLoggedInAlert.classList.remove('d-none')
+        : isLoggedOutAlert.classList.remove('d-none');
+      setTimeout(() => {
+        isLoggedInAlert.classList.add('d-none');
+        isLoggedOutAlert.classList.add('d-none');
+      }, 2000);
+    });
+  },
+  false
+);</code></pre>
+            <button type="button" class="btn btn-primary mb-2" id="is-login-button">Is Phone logged in?</button>
+            <div class="alert alert-success d-none" role="alert" id="is-logged-in">
+              Logged in
+            </div>
+            <div class="alert alert-danger d-none" role="alert" id="is-logged-out">
+              Logged out
+            </div>
+            <br/>
+            <br/>
+
+              <pre><code>dialButton.addEventListener(
+  'click',
+  () => {
+    ap.send('dial_number', { phone_number: '+33123456789' }, (success, data) => {
+      if (success) {
+        dialSuccessAlert.classList.remove('d-none');
+      } else {
+        dialErrorAlert.textContent = 'Error : ' + error.message;
+        dialErrorAlert.classList.remove('d-none');
+      }
+
+      setTimeout(() => {
+        dialSuccessAlert.classList.add('d-none');
+        dialErrorAlert.classList.add('d-none');
+      }, 2000);
+    });
+  },
+  false
+);</code></pre>
             <button type="button" class="btn btn-primary mb-2" id="dial-button">Dial +33 1 23 45 67 89</button>
+            <div class="alert alert-success d-none" role="alert" id="dial-number-success">
+              Success!
+            </div>
+            <div class="alert alert-danger d-none" role="alert" id="dial-number-error">
+              Error: 
+            </div>
 
             <p>Do you need more info? Read our documentation on <a href="https://github.com/aircall/aircall-everywhere">Github</a>
           </div>

--- a/scripts/webpack/webpack.build.js
+++ b/scripts/webpack/webpack.build.js
@@ -31,7 +31,7 @@ module.exports = () => {
         loader: 'babel-loader',
 
         options: {
-          presets: ['es2015']
+          presets: ['env']
         }
       }
     ]

--- a/scripts/webpack/webpack.test.js
+++ b/scripts/webpack/webpack.test.js
@@ -9,11 +9,13 @@ module.exports = {
         test: /\.jsx?$/,
         include: [path.resolve(__dirname, '../../src')],
         enforce: 'pre',
+        enforce: 'post',
 
         loader: 'babel-loader',
 
         options: {
-          plugins: ['babel-plugin-rewire']
+          plugins: ['babel-plugin-rewire'],
+          presets: ['env']
         }
       },
       {
@@ -30,7 +32,6 @@ module.exports = {
   },
 
   mode: 'development',
-
   resolve: {
     modules: ['node_modules', path.resolve(__dirname, '../../src/javascripts')],
     extensions: ['.js']

--- a/spec/javascripts/aircallPhone_spec.js
+++ b/spec/javascripts/aircallPhone_spec.js
@@ -17,14 +17,16 @@ describe('Aircall SDK Library', () => {
         phoneUrl: 'https://phone.aircall-staging.com',
         domToLoadPhone: '#phone',
         integrationToLoad: 'zendesk',
-        afterPhoneLoaded: () => {
+        onLogin: () => {
           console.log('loaded');
+        },
+        onLogout: () => {
+          console.log('logged out');
         }
       });
       expect(ap.phoneUrl).toBeDefined();
       expect(ap.domToLoadPhone).toBeDefined();
       expect(ap.integrationToLoad).toBeDefined();
-      expect(ap.afterPhoneLoaded).toBeDefined();
     });
 
     it('should launch _messageListener', () => {
@@ -143,7 +145,7 @@ describe('Aircall SDK Library', () => {
       expect(ap.integrationSettings).toEqual({ foo: 'bar' });
     });
 
-    it('should launch afterPhoneLoaded callback if defined after integration settings received', done => {
+    it('should launch onLogin callback if defined after integration settings received', done => {
       const win = {
         addEventListener: (type, callback, bool) => {
           setTimeout(() => {
@@ -154,7 +156,7 @@ describe('Aircall SDK Library', () => {
 
       const ap = new AircallPhone({
         window: win,
-        afterPhoneLoaded: () => {
+        onLogin: () => {
           done();
         }
       });
@@ -193,6 +195,7 @@ describe('Aircall SDK Library', () => {
 
     it('should send a postmessage that it is ready', done => {
       ap._handleInitMessage({
+        data: {},
         origin: '*',
         source: {
           postMessage: (event, target) => {
@@ -207,6 +210,7 @@ describe('Aircall SDK Library', () => {
     it('should ask for integration settings if there is an integration to load', done => {
       ap.integrationToLoad = 'salesforce';
       ap._handleInitMessage({
+        data: {},
         origin: '*',
         source: {
           postMessage: (event, target) => {
@@ -219,10 +223,11 @@ describe('Aircall SDK Library', () => {
     });
 
     it('should launch afterPhoneLoaded callback if there is no integration to load', done => {
-      ap.afterPhoneLoaded = () => {
+      ap.onLogin = () => {
         done();
       };
       ap._handleInitMessage({
+        data: {},
         origin: '*',
         source: {
           postMessage: (event, target) => {}
@@ -315,7 +320,7 @@ describe('Aircall SDK Library', () => {
     it('should log correct standard error message for error code not_ready', () => {
       ap._handleSendError({ code: 'not_ready' });
       expect(console.error).toHaveBeenCalledWith(
-        '[AircallEverywhere] [send function] Aircall Phone has not been identified yet or is not ready. Wait for "afterPhoneLoaded" callback'
+        '[AircallEverywhere] [send function] Aircall Phone has not been identified yet or is not ready. Wait for "onLogin" callback'
       );
     });
 
@@ -367,7 +372,7 @@ describe('Aircall SDK Library', () => {
           success === false &&
           data.code === 'not_ready' &&
           data.message ===
-            'Aircall Phone has not been identified yet or is not ready. Wait for "afterPhoneLoaded" callback'
+            'Aircall Phone has not been identified yet or is not ready. Wait for "onLogin" callback'
         ) {
           done();
         }

--- a/spec/javascripts/aircallPhone_spec.js
+++ b/spec/javascripts/aircallPhone_spec.js
@@ -330,4 +330,24 @@ describe('Aircall SDK Library', () => {
       }).toThrow();
     });
   });
+
+  describe('removeListener function', () => {
+    let ap;
+    beforeEach(() => {
+      ap = new AircallPhone();
+    });
+    it('should exists', () => {
+      expect(ap.removeListener).toBeDefined();
+    });
+  });
+
+  describe('isLoggedIn function', () => {
+    let ap;
+    beforeEach(() => {
+      ap = new AircallPhone();
+    });
+    it('should exists', () => {
+      expect(ap.isLoggedIn).toBeDefined();
+    });
+  });
 });

--- a/spec/javascripts/aircallPhone_spec.js
+++ b/spec/javascripts/aircallPhone_spec.js
@@ -433,6 +433,12 @@ describe('Aircall SDK Library', () => {
     beforeEach(() => {
       jasmine.clock().install();
       ap = new AircallPhone();
+      ap.phoneWindow = {
+        origin: '*',
+        source: {
+          postMessage: (event, target) => {}
+        }
+      };
     });
     it('should exists', () => {
       expect(ap.send).toBeDefined();
@@ -453,23 +459,11 @@ describe('Aircall SDK Library', () => {
     });
 
     it('should listen for a response to the sent event', () => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { foo: 'bar' });
       expect(ap.eventsRegistered.my_event_response).toBeDefined();
     });
 
     it('should timeout if no response sent by the phone', () => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { foo: 'bar' });
       spyOn(ap, '_handleSendError');
       jasmine.clock().tick(501);
@@ -477,24 +471,12 @@ describe('Aircall SDK Library', () => {
     });
 
     it('should remove listener for response after timeout', () => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { foo: 'bar' });
       jasmine.clock().tick(501);
       expect(ap.eventsRegistered.my_event_response).not.toBeDefined();
     });
 
     it('should remove listener on event response', () => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { foo: 'bar' });
       ap.eventsRegistered.my_event_response();
 
@@ -502,12 +484,6 @@ describe('Aircall SDK Library', () => {
     });
 
     it('should call _handleSendError on errorful event response', () => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { foo: 'bar' });
       spyOn(ap, '_handleSendError');
       ap.eventsRegistered.my_event_response({
@@ -522,12 +498,6 @@ describe('Aircall SDK Library', () => {
     });
 
     it('should call _handleSendError on malformed event response', () => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { foo: 'bar' });
       spyOn(ap, '_handleSendError');
       ap.eventsRegistered.my_event_response({ foo: 'bar' });
@@ -535,12 +505,6 @@ describe('Aircall SDK Library', () => {
     });
 
     it('should launch calbback on successful event response', done => {
-      ap.phoneWindow = {
-        origin: '*',
-        source: {
-          postMessage: (event, target) => {}
-        }
-      };
       ap.send('my_event', { toto: 'tata' }, (success, res) => {
         if (success === true && res.foo === 'bar') {
           done();

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -135,7 +135,7 @@ class AircallPhone {
       errorMessage = 'Invalid parameter eventName. Expected an non empty string';
       console.error(`[AircallEverywhere] [send function] ${errorMessage}`);
       if (typeof callback === 'function') {
-        callback(false, errorMessage);
+        callback(false, { errorMessage });
       }
     }
 
@@ -154,8 +154,23 @@ class AircallPhone {
         // we have a response, we remove listener and return the callback
         this.removeListener(`${eventName}_response`);
         clearTimeout(responseTimeout);
-        if (typeof callback === 'function') {
-          callback(true, response);
+        // we evaluate response
+        if (response && response.success === false) {
+          if (typeof callback === 'function') {
+            console.error(`[AircallEverywhere] [send function] ${response.errorMessage}`);
+            callback(false, { errorMessage: response.errorMessage });
+          }
+        } else if (response && response.success === true) {
+          if (typeof callback === 'function') {
+            callback(true, response.data);
+          }
+        } else {
+          if (typeof callback === 'function') {
+            errorMessage =
+              'Invalid response from the phone. Contact aircall developers dev@aircall.io';
+            console.error(`[AircallEverywhere] [send function] ${errorMessage}`);
+            callback(false, { errorMessage });
+          }
         }
       });
 
@@ -166,7 +181,7 @@ class AircallPhone {
         errorMessage = 'No answer from the phone. Check if the phone is logged in';
         console.error(`[AircallEverywhere] [send function] ${errorMessage}`);
         if (typeof callback === 'function') {
-          callback(false, errorMessage);
+          callback(false, { errorMessage });
         }
       }, timeoutLimit);
     } else {
@@ -174,7 +189,7 @@ class AircallPhone {
         'Aircall Phone has not been identified yet or is not ready. Wait for "afterPhoneLoaded" callback';
       console.error(`[AircallEverywhere] [send function] ${errorMessage}`);
       if (typeof callback === 'function') {
-        callback(false, errorMessage);
+        callback(false, { errorMessage });
       }
     }
   }

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -224,13 +224,13 @@ class AircallPhone {
         this.removeListener(`${eventName}_response`);
         clearTimeout(responseTimeout);
         // we evaluate response
-        if (response && response.success === false) {
+        if (!!response && response.success === false) {
           // phone answers with an error
           this._handleSendError(
             { code: response.errorCode, message: response.errorMessage },
             callback
           );
-        } else if (response && response.success === true) {
+        } else if (!!response && response.success === true) {
           // phone answer a succes with its response
           if (typeof callback === 'function') {
             callback(true, response.data);

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -131,7 +131,6 @@ class AircallPhone {
         code: 'unknown_error'
       };
     }
-
     // errors sent by the phone for specific events are not handled since they should have their code AND message
     if (!!error && !error.message) {
       switch (error.code) {
@@ -154,7 +153,7 @@ class AircallPhone {
           break;
         default:
           // specific error without a message. Should not happen
-          error.message = 'Generic error';
+          error.message = 'Generic error message';
           break;
       }
     }
@@ -225,16 +224,18 @@ class AircallPhone {
   }
 
   removeListener(eventName) {
-    if (!!this.eventsRegistered[eventName]) {
+    if (!this.eventsRegistered[eventName]) {
       return false;
     }
 
-    this.eventsRegistered = this.eventsRegistered.filter(e => e !== eventName);
+    Object.keys(this.eventsRegistered)
+      .filter(key => key === eventName)
+      .forEach(key => delete this.eventsRegistered[key]);
     return true;
   }
 
   isLoggedIn(callback) {
-    // we simply send an event and send its result
+    // we simply send an event and send its result. todo
   }
 }
 

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -4,6 +4,7 @@ class AircallPhone {
     // window object of loaded aircall phone
     this.phoneWindow = null;
     this.integrationSettings = {};
+    this.userSettings = {};
     this.eventsRegistered = {};
 
     const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi;
@@ -16,10 +17,11 @@ class AircallPhone {
         : 'https://phone.aircall.io';
     this.domToLoadPhone = opts.domToLoadPhone;
     this.integrationToLoad = opts.integrationToLoad;
+
     this.afterPhoneLoaded = () => {
       if (this.phoneStarted === false && typeof opts.afterPhoneLoaded === 'function') {
         this.phoneStarted = true;
-        opts.afterPhoneLoaded();
+        opts.afterPhoneLoaded(this.userSettings);
       }
     };
     // local window
@@ -91,6 +93,10 @@ class AircallPhone {
       source: event.source,
       origin: event.origin
     };
+
+    if (!!event.data.value) {
+      this.userSettings = event.data.value;
+    }
 
     // we answer init
     this.phoneWindow.source.postMessage({ name: 'apm_app_isready' }, this.phoneWindow.origin);

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -20,7 +20,6 @@ class AircallPhone {
     this.integrationToLoad = opts.integrationToLoad;
 
     this.onLogin = () => {
-      console.log('onlogin', this.userSettings);
       if (typeof opts.onLogin === 'function' && this.phoneLoginState === false) {
         this.phoneLoginState = true;
         const data = {
@@ -124,7 +123,6 @@ class AircallPhone {
     };
 
     if (!!event.data.value) {
-      console.log('toto');
       this.userSettings = event.data.value;
     }
 

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -20,6 +20,7 @@ class AircallPhone {
     this.integrationToLoad = opts.integrationToLoad;
 
     this.onLogin = () => {
+      console.log('onlogin', this.userSettings);
       if (typeof opts.onLogin === 'function' && this.phoneLoginState === false) {
         this.phoneLoginState = true;
         const data = {
@@ -123,6 +124,7 @@ class AircallPhone {
     };
 
     if (!!event.data.value) {
+      console.log('toto');
       this.userSettings = event.data.value;
     }
 
@@ -143,10 +145,6 @@ class AircallPhone {
 
   getUrlToLoad() {
     return `${this.phoneUrl}?integration=generic`;
-  }
-
-  getSetting(settingName) {
-    return this.integrationSettings[settingName];
   }
 
   on(eventName, callback) {
@@ -209,7 +207,7 @@ class AircallPhone {
 
     if (!eventName) {
       this._handleSendError({ code: 'no_event_name' }, callback);
-      return;
+      return false;
     }
 
     if (!!this.phoneWindow && !!this.phoneWindow.source) {
@@ -253,7 +251,7 @@ class AircallPhone {
       }, timeoutLimit);
     } else {
       this._handleSendError({ code: 'not_ready' }, callback);
-      return;
+      return false;
     }
   }
 


### PR DESCRIPTION
## error handling and send func response

### Description

Better send function overall, with a callback system with the response of the send: 
* first param: boolean if the send was a success or not.
* second param: response data if a success, error object if not, with an error code and an error message.

* `onLogin` and `onLogout` callbacks instead of `afterPhoneLoaded`. onLogin gives info about user and settings of integration if present
* `getSetting` removed
* `isLoggedIn` method (act as a ping)
* `removeListener` method added

⚠️ Can't be deployed before response handling is not in production on Phone project

### Submission

- [x] Your branch is based on `master`
- [x] Your code is unit tested
- [x] CircleCI builds are green (coverage and lint)
- [x] Add team "CTI" as "Reviewer" for the PR
- [x] Name your PR with the convention `fix|feat|impr(<subject>): description`.
