### PR TITLE
fix(initMessage): don't send a ready message if source has already been set up

### DIFF
--- a/spec/javascripts/aircallPhone_spec.js
+++ b/spec/javascripts/aircallPhone_spec.js
@@ -256,6 +256,20 @@ describe('Aircall SDK Library', () => {
       expect(ap._handleInitMessage).toBeDefined();
     });
 
+    it('should return if a source windows is already defined', () => {
+      ap.phoneWindow = {
+        source: 'foo',
+        origin: 'bar'
+      };
+      const res = ap._handleInitMessage({
+        data: {},
+        origin: '*',
+        source: 'toto'
+      });
+
+      expect(res).toBe(false);
+    });
+
     it('should send a postmessage that it is ready', done => {
       ap._handleInitMessage({
         data: {},

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -118,7 +118,7 @@ class AircallPhone {
   _handleInitMessage(event) {
     // we return if we already have a source defined
     if (!!this.phoneWindow) {
-      return;
+      return false;
     }
 
     // we keep the source

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -116,6 +116,11 @@ class AircallPhone {
   }
 
   _handleInitMessage(event) {
+    // we return if we already have a source defined
+    if (!!this.phoneWindow) {
+      return;
+    }
+
     // we keep the source
     this.phoneWindow = {
       source: event.source,


### PR DESCRIPTION
## PR Title

### Description

All is in the title. We don't send 'app_ready' more than once.

### Submission

- [ ] Your branch is based on `master`
- [ ] Your code is unit tested
- [ ] CircleCI builds are green (coverage and lint)
- [ ] Add team "CTI" as "Reviewer" for the PR
- [ ] Name your PR with the convention `fix|feat|impr(<subject>): description`.
