### PR TITLE
impr(logger): add _log func to control console logging with debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You need to create an instance to use the library. The constructor has a setting
   - `big`: 666px by 376px. Recommanded and default value
   - `small`: 600px by 376px
   - `auto`: 100% width and height. Not recommanded
+- `debug`: Enables or disables logging. Defaults to `true`.
 
 Example:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aircall-everywhere",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Library to embed and communicate with aircall-phone in any webpage",
   "main": "dist/index.js",
   "scripts": {

--- a/spec/javascripts/aircallPhone_spec.js
+++ b/spec/javascripts/aircallPhone_spec.js
@@ -23,12 +23,21 @@ describe('Aircall SDK Library', () => {
         },
         onLogout: () => {
           console.log('logged out');
-        }
+        },
+        debug: false
       });
       expect(ap.phoneUrl).toBeDefined();
       expect(ap.domToLoadPhone).toBeDefined();
       expect(ap.integrationToLoad).toBeDefined();
       expect(ap.size).toBeDefined();
+      expect(ap.debug).toBeDefined();
+      expect(ap.debug).toEqual(false);
+    });
+
+    it('should default debug mode to true', () => {
+      const ap = new AircallPhone();
+      expect(ap.debug).toBeDefined();
+      expect(ap.debug).toEqual(true);
     });
 
     it('should launch _messageListener', () => {
@@ -606,6 +615,56 @@ describe('Aircall SDK Library', () => {
         done();
       };
       ap.isLoggedIn(cb);
+    });
+  });
+
+  describe('_log function', () => {
+    beforeEach(() => {
+      spyOn(console, 'error');
+      spyOn(console, 'info');
+    });
+
+    it('should exist', () => {
+      const ap = new AircallPhone();
+      expect(ap._log).toBeDefined();
+    });
+
+    it('when `debug`=true, prints passed args with specified console action', () => {
+      const ap = new AircallPhone({ debug: true });
+      ap._log('info', 'some info');
+      ap._log('error', 'some error');
+
+      expect(console.info).toHaveBeenCalledWith('some info');
+      expect(console.error).toHaveBeenCalledWith('some error');
+    });
+
+    it('can print multiple arguments', () => {
+      const ap = new AircallPhone({ debug: true });
+      ap._log('info', 'some info', 'some more info');
+
+      expect(console.info).toHaveBeenCalledWith('some info', 'some more info');
+    });
+
+    it('defaults to info() if incorrect action is passed', () => {
+      const ap = new AircallPhone({ debug: true });
+      ap._log('foo', 'some info');
+
+      expect(console.info).toHaveBeenCalledWith('some info');
+    });
+
+    it('throws error when non-string action is passed', () => {
+      const ap = new AircallPhone({ debug: true });
+
+      expect(() => ap._log(() => {}, 'some info')).toThrow();
+    });
+
+    it('when `debug`=false, it does not print to console', () => {
+      const ap = new AircallPhone({ debug: false });
+      ap._log('info', 'some info');
+      ap._log('error', 'some error');
+
+      expect(console.info).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
## impr(logger): add _log func to control console logging with debug flag

### Description

Adds `_log` function and `debug` flag, so end-users can turn app logging on or off.

[https://aircall.atlassian.net/browse/ECO-76](https://aircall.atlassian.net/browse/ECO-76)

### Submission

- [x] Your branch is based on `master`
- [x] Your code is unit tested
- [ ] CircleCI builds are green (coverage and lint)
- [x] Add team "CTI" as "Reviewer" for the PR
- [x] Name your PR with the convention `fix|feat|impr(<subject>): description`.
