### PR TITLE
fix(clipboard): Allow clipboard through iframe

### DIFF
--- a/spec/javascripts/aircallPhone_spec.js
+++ b/spec/javascripts/aircallPhone_spec.js
@@ -101,7 +101,7 @@ describe('Aircall SDK Library', () => {
       ap.domToLoadPhone = '#phone';
       ap._createPhoneIframe();
       expect(HTMLElements['#phone'].innerHTML).toEqual(
-        '<iframe allow="microphone; autoplay" src="https://phone.aircall.io?integration=generic" style="height:666px; width:376px;"></iframe>'
+        '<iframe allow="microphone; autoplay; clipboard-read; clipboard-write" src="https://phone.aircall.io?integration=generic" style="height:666px; width:376px;"></iframe>'
       );
     });
 
@@ -110,7 +110,7 @@ describe('Aircall SDK Library', () => {
       ap.size = 'small';
       ap._createPhoneIframe();
       expect(HTMLElements['#phone'].innerHTML).toEqual(
-        '<iframe allow="microphone; autoplay" src="https://phone.aircall.io?integration=generic" style="height:600px; width:376px;"></iframe>'
+        '<iframe allow="microphone; autoplay; clipboard-read; clipboard-write" src="https://phone.aircall.io?integration=generic" style="height:600px; width:376px;"></iframe>'
       );
     });
 
@@ -119,7 +119,7 @@ describe('Aircall SDK Library', () => {
       ap.size = 'auto';
       ap._createPhoneIframe();
       expect(HTMLElements['#phone'].innerHTML).toEqual(
-        '<iframe allow="microphone; autoplay" src="https://phone.aircall.io?integration=generic" style="height:100%; width:100%;"></iframe>'
+        '<iframe allow="microphone; autoplay; clipboard-read; clipboard-write" src="https://phone.aircall.io?integration=generic" style="height:100%; width:100%;"></iframe>'
       );
     });
 

--- a/src/javascripts/aircallPhone.js
+++ b/src/javascripts/aircallPhone.js
@@ -77,7 +77,7 @@ class AircallPhone {
     // we get the passed dom
     try {
       const el = document.querySelector(this.domToLoadPhone);
-      el.innerHTML = `<iframe allow="microphone; autoplay" src="${this.getUrlToLoad()}" style="${sizeStyle}"></iframe>`;
+      el.innerHTML = `<iframe allow="microphone; autoplay; clipboard-read; clipboard-write" src="${this.getUrlToLoad()}" style="${sizeStyle}"></iframe>`;
     } catch (e) {
       // couldnt query the dom wanted
       this._log(


### PR DESCRIPTION
## PR Title

### Description

The user is reporting that the function "copy phone number" is not working anymore from his Aircall CTI. When he tries to click on it, and then paste it, it pastes the previous thing he copied.

Chrome v81 broke the copy paste in an iframe and Chrome v85 introduce feature policy https://chromestatus.com/feature/5767075295395840

### Submission

- [X] Your branch is based on `master`
- [X] Your code is unit tested
- [X] CircleCI builds are green (coverage and lint)
- [X] Add team "CTI" as "Reviewer" for the PR
- [X] Name your PR with the convention `fix|feat|impr(<subject>): description`.
