### PR TITLE
Impr(docs): call_end_ringtone is only triggered for inbound

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ All events from the phone with the payload associated:
     call_id: 12345
   }
   ```
-- `call_end_ringtone`: the ringtone has ended.
+- `call_end_ringtone`: the ringtone has ended. This event is only triggered for incoming calls.
   ```javascript
   {
     answer_status: 'answered | disconnected | refused',


### PR DESCRIPTION
## call_end_ringtone is only triggered for inbound

### Description

Update documentation to mention call_end_ringtone is only triggered for incoming calls.

### Submission

- [x] Your branch is based on `master`
- [ ] Your code is unit tested
- [x] CircleCI builds are green (coverage and lint)
- [x] Add team "CTI" as "Reviewer" for the PR
- [x] Name your PR with the convention `fix|feat|impr(<subject>): description`.
