### PR TITLE
impr: prevent some test suites from sending some logs

### DIFF
--- a/spec/javascripts/aircallPhone.spec.js
+++ b/spec/javascripts/aircallPhone.spec.js
@@ -476,7 +476,7 @@ describe('Aircall SDK Library', () => {
     let ap;
 
     beforeEach(() => {
-      ap = new AircallPhone();
+      ap = new AircallPhone({ debug: false });
       ap.phoneWindow = {
         origin: '*',
         source: {
@@ -613,7 +613,7 @@ describe('Aircall SDK Library', () => {
   describe('isLoggedIn function', () => {
     let ap;
 
-    beforeEach(() => (ap = new AircallPhone()));
+    beforeEach(() => (ap = new AircallPhone({ debug: false })));
 
     it('should exists', () => {
       expect(ap.isLoggedIn).toBeDefined();


### PR DESCRIPTION
## impr: Prevent some test suites from sending some logs

### Description

Simply passing `debug: false` to AircallPhone's constructor so that some test suites don't send useless logs

### Submission

- [x] Your branch is based on `master`
- [x] Your code is unit tested
- [x] CircleCI builds are green (coverage and lint)
- [x] Add team "CTI" as "Reviewer" for the PR
- [x] Name your PR with the convention `fix|feat|impr(<subject>): description`.
